### PR TITLE
reversecount, avoid fish on the first ice block

### DIFF
--- a/src/activities/reversecount/reversecount.js
+++ b/src/activities/reversecount/reversecount.js
@@ -268,6 +268,7 @@ function calculateNextPlaceFishToReach() {
     previousFishIndex = newFishIndex
 
     fishIndex = tuxIceBlockNumber + newFishIndex
+    if (fishIndex % iceBlocksLayout.length == 0) fishIndex++
 }
 
 function placeFishToReach() {


### PR DESCRIPTION
I have done a simple fix. When the rest of / 16 was equal to zero I incremented the fish position.
I tested and it seems to work.
