### PR TITLE
Task T4798 : Improving Letter-in-word activity

### DIFF
--- a/src/activities/letter-in-word/letter-in-word.js
+++ b/src/activities/letter-in-word/letter-in-word.js
@@ -246,7 +246,7 @@ function checkWord(index) {
         return true;
     }
     else {
-        items.bonus.bad("flower");
+        items.audioVoices.append(GCompris.ApplicationInfo.getAudioFilePath("voices-$CA/$LOCALE/misc/check_answer.$CA"))
         return false;
     }
 }
@@ -254,7 +254,6 @@ function checkWord(index) {
 function incorrectSelection() {
     incorrectFlag = true;
     var quesLen = questions.length;
-    questions = questions.slice(0, currentSubLevel) + questions.slice(currentSubLevel+1, quesLen) + questions.charAt(currentSubLevel);
     currentSubLevel--;
     nextSubLevel();
 }


### PR DESCRIPTION
Instead of showing "bad" bonus, when a wrong word is selected, the kid can be asked to check answer. This results in the word not getting selected and the kid stays on the same sublevel.