### PR TITLE
categorization:expert mode only on some categories

### DIFF
--- a/src/activities/categorization/categorization.js
+++ b/src/activities/categorization/categorization.js
@@ -212,12 +212,9 @@ function getCategoryLevels() {
     }
     // If expert mode is selected, select a random level (selectedLevel) from a random category (selectedCategory)
     else if(items.mode === "expert") {
-        var selectedCategory = Math.floor(Math.random() * lessons.length)
-        while( expertCategories.indexOf(selectedCategory) == -1 ) {
-            selectedCategory = Math.floor(Math.random() * lessons.length)
-        }
+        var selectedCategory = Math.floor(Math.random() * expertCategories.length)
         var selectedLevel = []
-        selectedLevel[0] = lessons[selectedCategory][Math.floor(Math.random() * lessons[selectedCategory].length)]
+        selectedLevel[0] = expertCategories[selectedCategory][Math.floor(Math.random() * expertCategories[selectedCategory].length)]
         items.details = selectedLevel.map(function(ele) {
             return { "instructions": ele.instructions,  "image": ele.image,
                 "numberOfGood": ele.maxNumberOfGood, "numberofBad": ele.maxNumberOfBad,
@@ -275,7 +272,7 @@ function getAllLessons(dataset) {
     for(var c = 0; c < dataset.length; c++) {
         lessons.push(dataset[c].levels[0].content)
         if(dataset[c].allowExpertMode) {
-            expertCategories.push(c)
+            expertCategories.push(dataset[c].levels[0].content)
         }
     }
     return lessons

--- a/src/activities/categorization/categorization.js
+++ b/src/activities/categorization/categorization.js
@@ -35,6 +35,7 @@ var numberOfLevel
 var index
 var imagesData = []
 var categoriesData = []
+var expertCategories = []
 var boardsUrl
 var answerTable = {}
 var totalImages
@@ -212,6 +213,9 @@ function getCategoryLevels() {
     // If expert mode is selected, select a random level (selectedLevel) from a random category (selectedCategory)
     else if(items.mode === "expert") {
         var selectedCategory = Math.floor(Math.random() * lessons.length)
+        while( expertCategories.indexOf(selectedCategory) == -1 ) {
+            selectedCategory = Math.floor(Math.random() * lessons.length)
+        }
         var selectedLevel = []
         selectedLevel[0] = lessons[selectedCategory][Math.floor(Math.random() * lessons[selectedCategory].length)]
         items.details = selectedLevel.map(function(ele) {
@@ -270,6 +274,9 @@ function getAllLessons(dataset) {
     var lessons = []
     for(var c = 0; c < dataset.length; c++) {
         lessons.push(dataset[c].levels[0].content)
+        if(dataset[c].allowExpertMode) {
+            expertCategories.push(c)
+        }
     }
     return lessons
 }

--- a/src/activities/categorization/resource/board/category_alphabets.qml
+++ b/src/activities/categorization/resource/board/category_alphabets.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject {
     property bool isEmbedded: true
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/src/activities/categorization/resource/images/alphabets/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_animals.qml
+++ b/src/activities/categorization/resource/board/category_animals.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/animals/"
     property variant levels:[
         {

--- a/src/activities/categorization/resource/board/category_birds.qml
+++ b/src/activities/categorization/resource/board/category_birds.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/birds/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_colors.qml
+++ b/src/activities/categorization/resource/board/category_colors.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_fishes.qml
+++ b/src/activities/categorization/resource/board/category_fishes.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject {
     property bool isEmbedded: true
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/src/activities/categorization/resource/images/fishes/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_food.qml
+++ b/src/activities/categorization/resource/board/category_food.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/food/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_fruits.qml
+++ b/src/activities/categorization/resource/board/category_fruits.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/src/activities/lang/resource/words_sample/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_household_goods.qml
+++ b/src/activities/categorization/resource/board/category_household_goods.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/householdGoods/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_insects.qml
+++ b/src/activities/categorization/resource/board/category_insects.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/insects/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_living_beings.qml
+++ b/src/activities/categorization/resource/board/category_living_beings.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_monuments.qml
+++ b/src/activities/categorization/resource/board/category_monuments.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject {
     property bool isEmbedded: true
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/src/activities/categorization/resource/images/monuments/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_nature.qml
+++ b/src/activities/categorization/resource/board/category_nature.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/nature/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_numbers.qml
+++ b/src/activities/categorization/resource/board/category_numbers.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject {
     property bool isEmbedded: true
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/src/activities/lang/resource/words_sample/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_odd_even.qml
+++ b/src/activities/categorization/resource/board/category_odd_even.qml
@@ -23,6 +23,7 @@ import QtQuick 2.0
 
 QtObject {
     property bool isEmbedded: false
+    property bool allowExpertMode: false
     property string imagesPrefix: "qrc:/gcompris/src/activities/lang/resource/words_sample/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_renewable.qml
+++ b/src/activities/categorization/resource/board/category_renewable.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject {
     property bool isEmbedded: true
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/src/activities/categorization/resource/images/renewable/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_shapes.qml
+++ b/src/activities/categorization/resource/board/category_shapes.qml
@@ -24,6 +24,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/shapes/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_tools.qml
+++ b/src/activities/categorization/resource/board/category_tools.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject {
     property bool isEmbedded: true
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/src/activities/categorization/resource/images/tools/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_transports.qml
+++ b/src/activities/categorization/resource/board/category_transports.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/transport/"
     property variant levels: [
         {

--- a/src/activities/categorization/resource/board/category_vegetables.qml
+++ b/src/activities/categorization/resource/board/category_vegetables.qml
@@ -22,6 +22,7 @@ import QtQuick 2.0
 
 QtObject{
     property bool isEmbedded: false
+    property bool allowExpertMode: true
     property string imagesPrefix: "qrc:/gcompris/data/words/vegetables/"
     property variant levels: [
         {


### PR DESCRIPTION
The expert mode on the categorization activity chooses randomly
from all the available categories. But among them, there may be
few categories which doesn't need an expert mode (example: the odd
even category)

The indices of the categories which are loaded in the current level
and which allows the expert mode is stored in an array. While
choosing a random index during expert mode, it is checked if it is
present in the array, if not, the randomisation process is repeated

Signed-off-by: Rudra Nil Basu <rudra.nil.basu.1996@gmail.com>