### PR TITLE
Config_Scroll:Hide "scroll_down" at bottom of page

### DIFF
--- a/src/core/DialogActivityConfig.qml
+++ b/src/core/DialogActivityConfig.qml
@@ -218,7 +218,7 @@ Rectangle {
                     onUp: flick.flick(0, 1400)
                     onDown: flick.flick(0, -1400)
                     upVisible: flick.visibleArea.yPosition <= 0 ? false : true
-                    downVisible: flick.visibleArea.yPosition >= 1 ? false : true
+                    downVisible: flick.visibleArea.yPosition >= 1.0 - flick.visibleArea.heightRatio ? false : true
                 }
             }
 


### PR DESCRIPTION
The scroll_down was visible even when we scrolled till the bottom
of the screen in the configuration menu. Since the page position
is in the range from 0.0 to 1.0 - size ratio, the range will be
from 0.0 to 1.0 - flick.visibleArea.heightRatio. Using this, the
scroll_down image gets disappeared when we are at the bottom of
the configuration page

Signed-off-by: Rudra Nil Basu <rudra.nil.basu.1996@gmail.com>