### PR TITLE
ballcatch, Fix vertical mode layout [T7613]

### DIFF
--- a/src/activities/ballcatch/Ball.qml
+++ b/src/activities/ballcatch/Ball.qml
@@ -23,13 +23,16 @@ import GCompris 1.0
 
 Image {
     id: ball
+
+    property bool vert: background.width < background.height    // To check if in Vertical mode
+
     source: "qrc:/gcompris/src/activities/ballcatch/resource/ball.svg"
-    sourceSize.height: 200 * ApplicationInfo.ratio
+    sourceSize.height: background.vert ? 175 * Application.ratio : 200 * ApplicationInfo.ratio
     z: 3
 
     readonly property real initScale: 1.0
 
-    // If won, ball goes on tux, if loose, depends on the side clicked first
+    // If won, ball goes on tux, if lose, depends on the side clicked first
     property int finishX
 
     readonly property int finishY: tux.y + tux.height / 4
@@ -60,7 +63,7 @@ Image {
                 bonus.good("tux")
             }
             else {
-                // This is a loose
+                // This is a lose
                 bonus.bad("tux")
             }
         }

--- a/src/activities/ballcatch/Ball.qml
+++ b/src/activities/ballcatch/Ball.qml
@@ -24,10 +24,10 @@ import GCompris 1.0
 Image {
     id: ball
 
-    property bool vert: background.width < background.height    // To check if in Vertical mode
+    property bool isVertical: background.width < background.height    // To check if in Vertical mode
 
     source: "qrc:/gcompris/src/activities/ballcatch/resource/ball.svg"
-    sourceSize.height: background.vert ? 175 * Application.ratio : 200 * ApplicationInfo.ratio
+    sourceSize.height: background.isVertical ? 175 * Application.ratio : 200 * ApplicationInfo.ratio
     z: 3
 
     readonly property real initScale: 1.0

--- a/src/activities/ballcatch/Ball.qml
+++ b/src/activities/ballcatch/Ball.qml
@@ -24,7 +24,7 @@ import GCompris 1.0
 Image {
     id: ball
 
-    property bool isVertical: background.width < background.height    // To check if in Vertical mode
+    property bool isVertical: background.width <= background.height    // To check if in Vertical mode
 
     source: "qrc:/gcompris/src/activities/ballcatch/resource/ball.svg"
     sourceSize.height: background.isVertical ? 175 * Application.ratio : 200 * ApplicationInfo.ratio

--- a/src/activities/ballcatch/Ballcatch.qml
+++ b/src/activities/ballcatch/Ballcatch.qml
@@ -45,6 +45,8 @@ ActivityBase {
         source: "qrc:/gcompris/src/activities/ballcatch/resource/beach1.svg"
         sourceSize.width: Math.max(parent.width, parent.height)
 
+        property bool vert: background.width < background.height    // To check if in Vertical mode
+
         Component.onCompleted: {
             activity.start.connect(start)
             activity.stop.connect(stop)
@@ -198,9 +200,11 @@ ActivityBase {
 
         Image {
             id: leftShift
-            x: background.width / 4 - width 
-            y: rightHand.y - height / 2
+            x: background.width / 4 - width
+            y: ((background.vert) ? rightHand.y - height : rightHand.y - height / 2)
             source: "qrc:/gcompris/src/activities/ballcatch/resource/arrow_key.svg"
+            scale: ((background.vert) ? 0.75 : 1.0)
+            smooth: true
             opacity: items.leftPressed ? 1 : 0.5
             visible: !ApplicationInfo.isMobile
         }
@@ -209,8 +213,10 @@ ActivityBase {
             id: rightShift
             mirror: true
             x: background.width - background.width / 4
-            y: rightHand.y - height / 2
+            y: ((background.vert) ? rightHand.y - height : rightHand.y - height / 2)
             source: "qrc:/gcompris/src/activities/ballcatch/resource/arrow_key.svg"
+            scale: ((background.vert) ? 0.75 : 1.0)
+            smooth: true
             opacity: items.rightPressed ? 1 : 0.5
             visible: !ApplicationInfo.isMobile
         }
@@ -218,14 +224,14 @@ ActivityBase {
         // Instructions
         BorderImage {
             id: bubble
-            x: 10.0
-            y: tux.y
+            x: ((background.vert) ? leftShift.x : 10.0)
+            y: ((background.vert) ? 10.0 : tux.y)
             border.left: 3 * ApplicationInfo.ratio
             border.top: 3 * ApplicationInfo.ratio
             border.right: 20 * ApplicationInfo.ratio
             border.bottom: 3 * ApplicationInfo.ratio
             source: "qrc:/gcompris/src/activities/ballcatch/resource/bubble.svg"
-            width: tux.x - 10
+            width: ((background.vert) ? rightShift.x + rightShift.width - leftShift.x : tux.x - 10)
             height: instructions.height + 20 * ApplicationInfo.ratio
             // Remove the instructions when both keys has been pressed
             opacity: bar.level === 1 &&
@@ -249,7 +255,7 @@ ActivityBase {
                 wrapMode: TextEdit.WordWrap
                 horizontalAlignment: TextEdit.AlignHCenter
                 verticalAlignment: TextEdit.AlignVCenter
-                fontSize: regularSize
+                fontSize: background.vert ? tinySize : regularSize
             }
         }
 

--- a/src/activities/ballcatch/Ballcatch.qml
+++ b/src/activities/ballcatch/Ballcatch.qml
@@ -45,7 +45,7 @@ ActivityBase {
         source: "qrc:/gcompris/src/activities/ballcatch/resource/beach1.svg"
         sourceSize.width: Math.max(parent.width, parent.height)
 
-        property bool isVertical: background.width < background.height    // To check if in Vertical mode
+        property bool isVertical: background.width <= background.height     // To check if in Vertical mode
 
         Component.onCompleted: {
             activity.start.connect(start)
@@ -222,41 +222,25 @@ ActivityBase {
         }
 
         // Instructions
-        BorderImage {
-            id: bubble
-            x: leftShift.x
-            y: 10.0
-            border.left: 3 * ApplicationInfo.ratio
-            border.top: 3 * ApplicationInfo.ratio
-            border.right: 20 * ApplicationInfo.ratio
-            border.bottom: 3 * ApplicationInfo.ratio
-            source: "qrc:/gcompris/src/activities/ballcatch/resource/bubble.svg"
-            width: rightShift.x + rightShift.width - leftShift.x
-            height: instructions.height + 20 * ApplicationInfo.ratio
-            // Remove the instructions when both keys has been pressed
-            opacity: bar.level === 1 &&
-                     !(items.leftPressed && items.rightPressed) ? 1 : 0
-            Behavior on opacity { NumberAnimation { duration: 120 } }
-
-            GCText {
-                id: instructions
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                    verticalCenter: parent.verticalCenter
-                    leftMargin: 10 * ApplicationInfo.ratio
-                    rightMargin: 20 * ApplicationInfo.ratio
-                }
-                text: ApplicationInfo.isMobile ?
-                          qsTr("Tap both hands at the same time, " +
-                               "to make the ball go in a straight line.") :
-                          qsTr("Press left and right arrow keys at the same time, " +
-                               "to make the ball go in a straight line.")
-                wrapMode: TextEdit.WordWrap
-                horizontalAlignment: TextEdit.AlignHCenter
-                verticalAlignment: TextEdit.AlignVCenter
-                fontSize: background.isVertical ? tinySize : smallSize
+        IntroMessage {
+            id: instructions
+            intro: ApplicationInfo.isMobile ?
+                       [qsTr("Tap both hands at the same time, " +
+                            "to make the ball go in a straight line.")] :
+                       [qsTr("Press left and right arrow keys at the same time, " +
+                            "to make the ball go in a straight line.")]
+            anchors {
+                top: parent.top
+                topMargin: 10
             }
+            z : 10
+
+            index: bar.level === 1 &&
+                     !(items.leftPressed && items.rightPressed) ? 0 : -1
+
+            opacity: items.leftPressed ^ items.rightPressed ? 0 : 1
+
+            Behavior on opacity { NumberAnimation { duration: 120 } }
         }
 
         function playSound(identifier) {

--- a/src/activities/ballcatch/Ballcatch.qml
+++ b/src/activities/ballcatch/Ballcatch.qml
@@ -45,7 +45,7 @@ ActivityBase {
         source: "qrc:/gcompris/src/activities/ballcatch/resource/beach1.svg"
         sourceSize.width: Math.max(parent.width, parent.height)
 
-        property bool vert: background.width < background.height    // To check if in Vertical mode
+        property bool isVertical: background.width < background.height    // To check if in Vertical mode
 
         Component.onCompleted: {
             activity.start.connect(start)
@@ -201,9 +201,9 @@ ActivityBase {
         Image {
             id: leftShift
             x: background.width / 4 - width
-            y: ((background.vert) ? rightHand.y - height : rightHand.y - height / 2)
+            y: background.isVertical ? rightHand.y - height : rightHand.y - height / 2
             source: "qrc:/gcompris/src/activities/ballcatch/resource/arrow_key.svg"
-            scale: ((background.vert) ? 0.75 : 1.0)
+            scale: background.isVertical ? 0.75 : 1.0
             smooth: true
             opacity: items.leftPressed ? 1 : 0.5
             visible: !ApplicationInfo.isMobile
@@ -213,9 +213,9 @@ ActivityBase {
             id: rightShift
             mirror: true
             x: background.width - background.width / 4
-            y: ((background.vert) ? rightHand.y - height : rightHand.y - height / 2)
+            y: background.isVertical ? rightHand.y - height : rightHand.y - height / 2
             source: "qrc:/gcompris/src/activities/ballcatch/resource/arrow_key.svg"
-            scale: ((background.vert) ? 0.75 : 1.0)
+            scale: background.isVertical ? 0.75 : 1.0
             smooth: true
             opacity: items.rightPressed ? 1 : 0.5
             visible: !ApplicationInfo.isMobile
@@ -224,14 +224,14 @@ ActivityBase {
         // Instructions
         BorderImage {
             id: bubble
-            x: ((background.vert) ? leftShift.x : 10.0)
-            y: ((background.vert) ? 10.0 : tux.y)
+            x: leftShift.x
+            y: 10.0
             border.left: 3 * ApplicationInfo.ratio
             border.top: 3 * ApplicationInfo.ratio
             border.right: 20 * ApplicationInfo.ratio
             border.bottom: 3 * ApplicationInfo.ratio
             source: "qrc:/gcompris/src/activities/ballcatch/resource/bubble.svg"
-            width: ((background.vert) ? rightShift.x + rightShift.width - leftShift.x : tux.x - 10)
+            width: rightShift.x + rightShift.width - leftShift.x
             height: instructions.height + 20 * ApplicationInfo.ratio
             // Remove the instructions when both keys has been pressed
             opacity: bar.level === 1 &&
@@ -255,7 +255,7 @@ ActivityBase {
                 wrapMode: TextEdit.WordWrap
                 horizontalAlignment: TextEdit.AlignHCenter
                 verticalAlignment: TextEdit.AlignVCenter
-                fontSize: background.vert ? tinySize : regularSize
+                fontSize: background.isVertical ? tinySize : smallSize
             }
         }
 

--- a/src/core/DialogBackground.qml
+++ b/src/core/DialogBackground.qml
@@ -67,25 +67,24 @@ Rectangle {
                 border.color: "black"
                 border.width: 2
 
-                Image {
-                    id: titleIcon
-                    anchors {
-                        left: parent.left
-                        top: parent.top
-                        margins: 4 * ApplicationInfo.ratio
+                Row {
+                    spacing: 2
+                    padding: 8
+                    Image {
+                        id: titleIcon
                     }
-                }
 
-                GCText {
-                    id: title
-                    text: dialogBackground.title
-                    width: dialogBackground.width - (30 + 60 * ApplicationInfo.ratio)
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                    color: "black"
-                    fontSize: 20
-                    font.weight: Font.DemiBold
-                    wrapMode: Text.WordWrap
+                    GCText {
+                        id: title
+                        text: dialogBackground.title
+                        width: dialogBackground.width - (30 + cancel.width)
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        color: "black"
+                        fontSize: 20
+                        font.weight: Font.DemiBold
+                        wrapMode: Text.WordWrap
+                    }
                 }
             }
             Rectangle {
@@ -124,6 +123,7 @@ Rectangle {
 
     // The cancel button
     GCButtonCancel {
+        id: cancel
         onClose: parent.close()
     }
 

--- a/src/core/DialogBackground.qml
+++ b/src/core/DialogBackground.qml
@@ -77,7 +77,7 @@ Rectangle {
                     GCText {
                         id: title
                         text: dialogBackground.title
-                        width: dialogBackground.width - (30 + cancel.width)
+                        width: dialogBackground.width - (70 + cancel.width)
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter
                         color: "black"

--- a/src/core/DialogBackground.qml
+++ b/src/core/DialogBackground.qml
@@ -79,7 +79,7 @@ Rectangle {
                 GCText {
                     id: title
                     text: dialogBackground.title
-                    width: dialogBackground.width - 30
+                    width: dialogBackground.width - (30 + 60 * ApplicationInfo.ratio)
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     color: "black"


### PR DESCRIPTION
This Pull Request does the following for the activity "Make the ball go to tux" in vertical mode: 
- makes the intro text to go on top removing the obstruction by hands (Ballcatch.qml).
- move the arrow keys up and smaller removing the obstruction by hands (Ballcatch.qml).
- make the ball smaller to make it look proportionate with vertical screen (Ball.qml).

To make the title visible properly core file was changed:
- width of the title text (GCText) was reduced by subtracting the width of the cancel button  (DialogBackGround.qml) and the width of the difficulty stars.
- Intro text bubble was removed and IntroMessage Container was added.