### PR TITLE
letter_in_word: Fixing overriding issues with images when expanded

### DIFF
--- a/src/activities/letter-in-word/Card.qml
+++ b/src/activities/letter-in-word/Card.qml
@@ -42,6 +42,17 @@ Item {
     }
 
     Image {
+        id: tick
+        source: "qrc:/gcompris/src/core/resource/apply.svg"
+        sourceSize.width: cardImage.width / 3
+        visible: false
+
+        anchors {
+            leftMargin: cardItem.right - 0.01
+            bottomMargin: parent.top - 10
+        }
+    }
+    Image {
         id: cardImage
         anchors.top: wordPic.bottom
         anchors.topMargin: -30 * ApplicationInfo.ratio
@@ -72,11 +83,10 @@ Item {
 
         states:
             State {
-                name: "scaled"; when: selected && mouseActive
+                name: "marked"; when: selected && mouseActive
                 PropertyChanges {
-                    target: cardItem
-                    scale: 1.5
-                    z: 2
+                    target: tick
+                    visible: true
                 }
             }
 

--- a/src/activities/letter-in-word/LetterInWord.qml
+++ b/src/activities/letter-in-word/LetterInWord.qml
@@ -328,8 +328,8 @@ ActivityBase {
             anchors.leftMargin: 15 * ApplicationInfo.ratio
             anchors.rightMargin: 15 * ApplicationInfo.ratio
             anchors.bottomMargin: 10 * ApplicationInfo.ratio
-            cellWidth: itemWidth + 25*ApplicationInfo.ratio
-            cellHeight: itemHeight + 15*ApplicationInfo.ratio
+            cellWidth: itemWidth + 25 * ApplicationInfo.ratio
+            cellHeight: itemHeight + 15 * ApplicationInfo.ratio
             clip: false
             interactive: false
             //verticalLayoutDirection: GridView.BottomToTop


### PR DESCRIPTION
Added a tick mark instead of scaling the selected object.
Previous PR : https://github.com/gcompris/GCompris-qt/pull/215