### PR TITLE
core, Fix hidden text in help [T8049]

### DIFF
--- a/src/core/DialogBackground.qml
+++ b/src/core/DialogBackground.qml
@@ -93,7 +93,7 @@ Rectangle {
                 color: "#e6e6e6"
                 radius: 6.0
                 width: dialogBackground.width - 30
-                height: dialogBackground.height - 100
+                height: dialogBackground.height - (30 + title.height * 1.2)
                 border.color: "black"
                 border.width: 2
                 anchors.margins: 100


### PR DESCRIPTION
This PR fixes the partly hidden text of Help section in vertical mode of a few activities where the title is in more than one line.
Changed the height of the Rectangle to consider the change in height of title.
Files changed : DialogBackground.qml