### PR TITLE
canal_lock, add intromessage

### DIFF
--- a/src/activities/canal_lock/CanalLock.qml
+++ b/src/activities/canal_lock/CanalLock.qml
@@ -46,6 +46,27 @@ ActivityBase {
             activity.start.connect(start)
             activity.stop.connect(stop)
         }
+        
+        IntroMessage {
+            id: message
+            anchors {
+                top: parent.top
+                topMargin: 10
+                right: parent.right
+                rightMargin: 5
+                left: parent.left
+                leftMargin: 5
+            }
+            z: 100
+            intro: [      
+                qsTr("Your goal is to get Tux across the canal lock to get the wooden logs, "
+                     +"using the different types of water locks available."),
+                qsTr("The vertical colored bars represent the water locks, which can be operated by clicking them. "
+                     +"Two locks of the same type cannot be operated simultaneously.") ,
+                qsTr("The water level inside the lock will change according to the side of the canal it is "
+                     +"connected with. Use this property to help Tux get his job done.")
+            ]
+        }
 
         onStart: water.state = 'down'
 


### PR DESCRIPTION
Add an intro message to canal lock activity to help children figure out how to work with the activity.
![screen3](https://user-images.githubusercontent.com/25455546/45263218-ed7c7d00-b442-11e8-83e2-f8470db0a4d5.png)

![screen2](https://user-images.githubusercontent.com/25455546/45262861-bd31e000-b43c-11e8-90ae-ab6f63266878.png)

