### PR TITLE
core, add configuration modes for Domino component

### DIFF
--- a/src/activities/reversecount/ChooseDiceBar.qml
+++ b/src/activities/reversecount/ChooseDiceBar.qml
@@ -33,6 +33,7 @@ Item {
     property alias value1: domino.value1
     property alias value2: domino.value2
     property alias valueMax: domino.valueMax
+    property alias mode: domino.mode
     property GCSfx audioEffects
 
     Row {

--- a/src/activities/reversecount/Reversecount.qml
+++ b/src/activities/reversecount/Reversecount.qml
@@ -42,6 +42,7 @@ ActivityBase {
         signal stop
 
         Component.onCompleted: {
+            dialogActivityConfig.getInitialConfiguration()
             activity.start.connect(start)
             activity.stop.connect(stop)
         }
@@ -59,6 +60,7 @@ ActivityBase {
             property alias tux: tux
             property alias fishToReach: fishToReach
             property int clockPosition: 4
+            property string mode: "dot"
         }
 
         onStart: { Activity.start(items) }
@@ -162,13 +164,18 @@ ActivityBase {
 
         Bar {
             id: bar
-            content: BarEnumContent { value: help | home | level }
+            content: BarEnumContent { value: help | home | level | config}
             onHelpClicked: {
                 displayDialog(dialogHelp)
             }
             onPreviousLevelClicked: Activity.previousLevel()
             onNextLevelClicked: Activity.nextLevel()
             onHomeClicked: activity.home()
+            onConfigClicked: {
+                dialogActivityConfig.active = true
+                dialogActivityConfig.setDefaultValues()
+                displayDialog(dialogActivityConfig)
+            }
         }
 
         Image {
@@ -213,8 +220,57 @@ ActivityBase {
             }
         }
 
+        DialogActivityConfig {
+            id: dialogActivityConfig
+            currentActivity: activity
+            content: Component {
+                Item {
+                    property alias modeBox: modeBox
+                    property var availableModes: [
+                        { "text": qsTr("Dots"), "value": "dot" },
+                        { "text": qsTr("Numbers"), "value": "number" },
+                        { "text": qsTr("Romans"), "value": "roman" }
+                    ]
+                    Flow {
+                        id: flow
+                        spacing: 5
+                        width: dialogActivityConfig.width
+                        GCComboBox {
+                            id: modeBox
+                            model: availableModes
+                            background: dialogActivityConfig
+                            label: qsTr("Select Domino Representation")
+                        }
+                    }
+                }
+            }
+            onClose: home()
+            onLoadData: {
+                if(dataToSave && dataToSave["mode"]) {
+                    items.mode = dataToSave["mode"];
+                }
+            }
+            onSaveData: {
+                var newMode = dialogActivityConfig.configItem.availableModes[dialogActivityConfig.configItem.modeBox.currentIndex].value;
+                if (newMode !== items.mode) {
+                    items.mode = newMode;
+                    dataToSave = {"mode": items.mode};
+                }
+                Activity.initLevel();
+            }
+            function setDefaultValues() {
+                for(var i = 0 ; i < dialogActivityConfig.configItem.availableModes.length ; i++) {
+                    if(dialogActivityConfig.configItem.availableModes[i].value === items.mode) {
+                        dialogActivityConfig.configItem.modeBox.currentIndex = i;
+                        break;
+                    }
+                }
+            }
+        }
+
         ChooseDiceBar {
             id: chooseDiceBar
+            mode: items.mode
             x: background.width / 5 + 20
             y: (background.height - background.height/5) * 3 / 5
             audioEffects: activity.audioEffects

--- a/src/core/Domino.qml
+++ b/src/core/Domino.qml
@@ -59,6 +59,15 @@ Flipable {
     property color backColor: "white"
     property color pointColor: "black"
 
+    // Define the mode/representation of domino
+    // "dot" is for representation in the form of dots
+    // "number" is for representation in the form of integer numbers
+    // "roman" is for representation in the form of roman numbers
+    property string mode: "dot"
+
+    // Source of the images should be in the same format as below with the number associated and svg format
+    property string source: "qrc:/gcompris/src/activities/memory-enumerate/resource/math_"
+
     // Set to true when to display on both sides.
     property bool flipEnabled: false
 
@@ -78,6 +87,7 @@ Flipable {
 
         DominoNumber {
             id: number1
+            mode: flipable.mode
             width: parent.width / 2
             height: parent.height
             color: flipable.pointColor
@@ -85,6 +95,7 @@ Flipable {
             borderWidth: 0
             radius: parent.height * 0.25
             valueMax: flipable.valueMax
+            source: flipable.source
             onValueChanged: if(flipEnabled) flipable.flipped = !flipable.flipped
             isClickable: flipable.isClickable
             audioEffects: flipable.audioEffects
@@ -99,8 +110,10 @@ Flipable {
             color: flipable.borderColor
         }
 
+
         DominoNumber {
             id: number2
+            mode: flipable.mode
             x: parent.width / 2
             width: parent.width / 2
             height: parent.height
@@ -109,6 +122,7 @@ Flipable {
             borderWidth: 0
             radius: parent.height * 0.25
             valueMax: flipable.valueMax
+            source: flipable.source
             onValueChanged: if(flipEnabled) flipable.flipped = !flipable.flipped
             isClickable: flipable.isClickable
             audioEffects: flipable.audioEffects

--- a/src/core/DominoNumber.qml
+++ b/src/core/DominoNumber.qml
@@ -23,7 +23,7 @@ import GCompris 1.0
 
 /**
  * A QML component to display integers(0-9) on Domino.
- * Numbers are displayed in the form of number of circles.
+ * Numbers are displayed in the form of specified representation.
  *
  * @inherit QtQuick.Item
  */
@@ -35,6 +35,12 @@ Item {
      * Integer to display on the domino
      */
     property int value
+
+    /**
+     * type:string
+     * String to specify representation of Domino
+     */
+    property string mode
 
     /**
      * type:int
@@ -78,6 +84,36 @@ Item {
      */
     property GCSfx audioEffects
 
+    /**
+     * type:string
+     * String to specify the source folder for the image mode
+     */
+    property string source
+
+    readonly property variant romans : ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX"]
+
+    GCText {
+        id: numberText
+        visible: (item.mode == "number" || item.mode == "roman")
+        fontSize: ((item.mode == "number") ? 30 : (item.value == 8) ? 20 : (item.value == 7 || item.value == 3) ? 25 : 30)
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        color: item.color
+        anchors.margins: ApplicationInfo.ratio * 5
+        text: (mode == "number") ? item.value : romans[item.value]
+    }
+
+    Image {
+        id: imageText
+        visible: (item.mode == "image")
+        height: parent.height
+        fillMode: Image.PreserveAspectFit
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.margins: ApplicationInfo.ratio * 5
+        source: item.source + item.value + ".svg"
+    }
+
     function isVisible(index) {
         var value = item.value
         var visible = false
@@ -117,6 +153,7 @@ Item {
     Grid {
         columns: 3
         spacing: 3
+        visible: (item.mode == "dot")
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
         horizontalItemAlignment: Grid.AlignHCenter
@@ -137,6 +174,7 @@ Item {
             }
         }
     }
+
 
     // Increase the displayed integer value by one.
     function up() {


### PR DESCRIPTION
Two modes have been added(for simple and roman numbers) and a configuration menu in reversecount activity has been created.
![image](https://user-images.githubusercontent.com/25455546/48317446-669d7980-e618-11e8-9a80-faeb9862b212.png)
![image](https://user-images.githubusercontent.com/25455546/48317453-8c2a8300-e618-11e8-9d62-043df0a5abc2.png)

![image](https://user-images.githubusercontent.com/25455546/48505211-83ca8600-e86c-11e8-9e36-09c70d568ce9.png)

