### PR TITLE
solar system: improve hint system 

### DIFF
--- a/src/activities/solar_system/Dataset.js
+++ b/src/activities/solar_system/Dataset.js
@@ -28,27 +28,32 @@ function get() {
                         { 	// sub-level 1
                             "question": qsTr("How large is the Sun compared to the planets in our Solar System?"),
                             "options": [qsTr("Sixth largest"), qsTr("Third largest"), qsTr("Largest"), qsTr("Seventh largest")],
-                            "closeness": [17.5, 67, 100, 1]
+                            "closeness": [17.5, 67, 100, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 2
                             "question": qsTr("The temperature of the Sun is around:"),
                             "options": [qsTr("1000 °C"), qsTr("4500 °C"), qsTr("5505 °C"), qsTr("3638 °C")],
-                            "closeness": [1, 78, 100, 60]
+                            "closeness": [1, 78, 100, 60],
+                             "hintprovide": 1
                         },
                         { 	// sub-level 3
                             "question": qsTr("How old is the Sun?"),
                             "options": [qsTr("1.2 billion years"), qsTr("3 billion years"), qsTr("7 billion years"), qsTr("4.5 billion years")],
-                            "closeness": [1, 55, 25, 100]
+                            "closeness": [1, 55, 25, 100],
+                             "hintprovide": 0
                         },
                         { 	// sub-level 4
                             "question": qsTr("How long does it take for the Sun’s light to reach the Earth?"),
                             "options": [qsTr("8 minutes"), qsTr("30 minutes"), qsTr("60 minutes"), qsTr("15 minutes")],
-                            "closeness": [100, 58, 1, 86.6]
+                            "closeness": [100, 58, 1, 86.6],
+                             "hintprovide": 0
                         },
                         { 	// sub-level 5
                             "question": qsTr("The Sun is as big as:"),
                             "options": [qsTr("1 million Earths"), qsTr("2.6 million Earths"), qsTr("1.3 million Earths"), qsTr("5 million Earths")],
-                            "closeness": [92, 65, 100, 1]
+                            "closeness": [92, 65, 100, 1],
+                             "hintprovide": 0
                         }
                     ]
                 },
@@ -62,32 +67,38 @@ function get() {
                         { 	// sub-level 1
                             "question": qsTr("At which position is Mercury in the Solar System?"),
                             "options": [qsTr("Seventh"), qsTr("Sixth"), qsTr("First"), qsTr("Fourth")],
-                            "closeness": [1, 17.5, 100, 50.5]
+                            "closeness": [1, 17.5, 100, 50.5],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 2
                             "question": qsTr("How small is Mercury compared to other planets in our Solar System?"),
                             "options": [qsTr("Smallest"), qsTr("Second smallest"), qsTr("Third smallest"), qsTr("Fifth smallest")],
-                            "closeness": [100, 75.3, 50.5, 1]
+                            "closeness": [100, 75.3, 50.5, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 3
                             "question": qsTr("How many moons has Mercury?"),
                             "options": ["5", "200", "0", "10"],
-                            "closeness": [97.5, 1, 100, 95]
+                            "closeness": [97.5, 1, 100, 95],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 4
                             "question": qsTr("The maximum temperature on Mercury is:"),
                             "options": [qsTr("50 °C"), qsTr("35 °C"), qsTr("427 °C"), qsTr("273 °C")],
-                            "closeness": [4.8, 1, 100, 61]
+                            "closeness": [4.8, 1, 100, 61],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 5
                             "question": qsTr("How many days make a year on Mercury?"),
                             "options": [qsTr("365 days"), qsTr("433 days"), qsTr("88 days"), qsTr("107 days")],
-                            "closeness": [20.5, 1, 100, 94.5]
+                            "closeness": [20.5, 1, 100, 94.5],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 6
                             "question": qsTr("How long is one rotation on Mercury?"),
                             "options": [qsTr("50 Earth days"), qsTr("365 Earth days"), qsTr("59 Earth days"), qsTr("107 Earth days")],
-                            "closeness": [97, 1, 100, 84.4]
+                            "closeness": [97, 1, 100, 84.4],
+                            "hintprovide": 0
                         }
                     ]
                 },
@@ -101,37 +112,44 @@ function get() {
                         { 	// sub-level 1
                             "question": qsTr("At which position is Venus in the Solar System?"),
                             "options": [qsTr("Seventh"), qsTr("Sixth"), qsTr("Second"), qsTr("Fourth")],
-                            "closeness": [1, 20.8, 100, 60.4]
+                            "closeness": [1, 20.8, 100, 60.4],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 2
                             "question": qsTr("Venus is as heavy as:"),
                             "options": [qsTr("0.7 Earths"), qsTr("0.8 Earths"), qsTr("1.3 Earths"), qsTr("2.5 Earths")],
-                            "closeness": [94, 100, 71, 1]
+                            "closeness": [94, 100, 71, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 3
                             "question": qsTr("How large is Venus compared to other planets in our Solar System?"),
                             "options": [qsTr("Seventh largest"), qsTr("Sixth largest"), qsTr("Fifth largest"), qsTr("Fourth largest")],
-                            "closeness": [50.5, 100, 50.5, 1]
+                            "closeness": [50.5, 100, 50.5, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 4
                             "question": qsTr("How long is a year on Venus?"),
                             "options": [qsTr("225 days"), qsTr("365 days"), qsTr("116 days"), qsTr("100 days")],
-                            "closeness": [100, 1, 23, 11.6]
+                            "closeness": [100, 1, 23, 11.6],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 5
                             "question": qsTr("How long is one rotation on Venus?"),
                             "options": [qsTr("117 Earth days"), qsTr("365 Earth days"), qsTr("88 Earth days"), qsTr("107 Earth days")],
-                            "closeness": [100, 1, 88.8, 96.4]
+                            "closeness": [100, 1, 88.8, 96.4],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 6
                             "question": qsTr("The maximum temperature on Venus is:"),
                             "options": [qsTr("100 °C"), qsTr("20 °C"), qsTr("467 °C"), qsTr("45 °C")],
-                            "closeness": [18.7, 1, 100, 6.5]
+                            "closeness": [18.7, 1, 100, 6.5],
+                            "hintprovide": 1
                         },
                         {   // sub-level 7
                             "question": qsTr("How many moons has Venus?"),
                             "options": ["5", "10", "2", "0"],
-                            "closeness": [50, 1, 80, 100]
+                            "closeness": [50, 1, 80, 100],
+                            "hintprovide": 0
                         }
                     ]
                 },
@@ -145,37 +163,44 @@ function get() {
                         { 	// sub-level 1
                             "question": qsTr("At which position is Earth in the Solar System?"),
                             "options": [qsTr("Sixth"), qsTr("Third"), qsTr("First"), qsTr("Fifth")],
-                            "closeness": [1, 100, 35, 35]
+                            "closeness": [1, 100, 35, 35],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 2
                             "question": qsTr("How long does it take for Earth to make one revolution around the Sun?"),
                             "options": [qsTr("200 days"), qsTr("30 days"), qsTr("7 days"), qsTr("365 days")],
-                            "closeness": [54.3, 7.3, 1, 100]
+                            "closeness": [54.3, 7.3, 1, 100],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 3
                             "question": qsTr("How many moons has Earth?"),
                             "options": ["1", "5", "2", "3"],
-                            "closeness": [100, 15, 75, 50.5]
+                            "closeness": [100, 15, 75, 50.5],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 4
                             "question": qsTr("How long is one rotation on Earth?"),
                             "options": [qsTr("12 hours"), qsTr("24 hours"), qsTr("365 hours"), qsTr("48 hours")],
-                            "closeness": [96.5, 100, 1, 93]
+                            "closeness": [96.5, 100, 1, 93],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 5
                             "question": qsTr("How many seasons has Earth?"),
                             "options": ["2", "4", "6", "1"],
-                            "closeness": [34, 100, 34, 1]
+                            "closeness": [34, 100, 34, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 6
                             "question": qsTr("Maximum temperature on Earth is:"),
                             "options": [qsTr("100 °C"), qsTr("58 °C"), qsTr("30 °C"), qsTr("45 °C")],
-                            "closeness": [1, 100, 33, 69.3]
+                            "closeness": [1, 100, 33, 69.3],
+                            "hintprovide": 1
                         },
                         {   // sub-level 7
                             "question": qsTr("How large is Earth compared to other planets in our Solar System?"),
                             "options": [qsTr("Seventh largest"), qsTr("Sixth largest"), qsTr("Fifth largest"), qsTr("Fourth largest")],
-                            "closeness": [1, 50.5, 100, 50.5]
+                            "closeness": [1, 50.5, 100, 50.5],
+                            "hintprovide": 0
                         }
                     ]
                 },
@@ -189,37 +214,44 @@ function get() {
                         { 	// sub-level 1
                             "question": qsTr("At which position is Mars in the Solar System?"),
                             "options": [qsTr("Sixth"), qsTr("Fourth"), qsTr("First"), qsTr("Fifth")],
-                            "closeness": [34, 100, 1, 67]
+                            "closeness": [34, 100, 1, 67],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 2
                             "question": qsTr("The maximum temperature on Mars is:"),
                             "options": [qsTr("20 °C"), qsTr("35 °C"), qsTr("100 °C"), qsTr("60 °C")],
-                            "closeness": [100, 81.4, 1, 51.5]
+                            "closeness": [100, 81.4, 1, 51.5],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 3
                             "question": qsTr("How big is the size of Mars compared to Earth?"),
                             "options": [qsTr("The same"), qsTr("Half"), qsTr("Two times"), qsTr("Three times")],
-                            "closeness": [80, 100, 40.6, 1]
+                            "closeness": [80, 100, 40.6, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 4
                             "question": qsTr("How many moons has Mars?"),
                             "options": ["1", "5", "2", "3"],
-                            "closeness": [67, 1, 100, 50.5]
+                            "closeness": [67, 1, 100, 50.5],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 5
                             "question": qsTr("How long is one rotation on Mars?"),
                             "options": [qsTr("12 hours"), qsTr("24 hours"), qsTr("24.5 hours"), qsTr("48 hours")],
-                            "closeness": [47.3, 91, 100, 1]
+                            "closeness": [47.3, 91, 100, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 6
                             "question": qsTr("How long does it take for Mars to make one revolution around the Sun?"),
                             "options": [qsTr("687 days"), qsTr("30 days"), qsTr("7 days"), qsTr("365 days")],
-                            "closeness": [100, 4.3, 1, 53]
+                            "closeness": [100, 4.3, 1, 53],
+                            "hintprovide": 1
                         },
                         {   // sub-level 7
                             "question": qsTr("How small is Mars compared to other planets in our Solar System?"),
                             "options": [qsTr("Smallest"), qsTr("Second smallest"), qsTr("Third smallest"), qsTr("Fifth smallest")],
-                            "closeness": [67, 100, 67, 1]
+                            "closeness": [67, 100, 67, 1],
+                            "hintprovide": 0
                         }
                     ]
                 },
@@ -233,32 +265,38 @@ function get() {
                         { 	// sub-level 1
                             "question": qsTr("At which position is Jupiter in the Solar System?"),
                             "options": [qsTr("Sixth"), qsTr("Fifth"), qsTr("First"), qsTr("Fourth")],
-                            "closeness": [75, 100, 1, 75]
+                            "closeness": [75, 100, 1, 75],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 2
                             "question": qsTr("How large is Jupiter compared to other planets in the Solar System?"),
                             "options": [qsTr("Third largest"), qsTr("Largest"), qsTr("Fifth largest"), qsTr("Second largest")],
-                            "closeness": [50.5, 100, 1, 75]
+                            "closeness": [50.5, 100, 1, 75],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 3
                             "question": qsTr("The minimum temperature on Jupiter is:"),
                             "options": [qsTr("-145 °C"), qsTr("100 °C"), qsTr("50 °C"), qsTr("-180 °C")],
-                            "closeness": [100, 63, 24.7, 1]
+                            "closeness": [100, 63, 24.7, 1],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 4
                             "question": qsTr("How many moons has Jupiter?"),
                             "options": ["1", "79", "25", "53"],
-                            "closeness": [1, 100, 32.1, 67.9]
+                            "closeness": [1, 100, 32.1, 67.9],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 5
                             "question": qsTr("How long is one rotation on Jupiter?"),
                             "options": [qsTr("10 hours"), qsTr("24 hours"), qsTr("12 hours"), qsTr("48 hours")],
-                            "closeness": [100, 63.5, 94.8, 1]
+                            "closeness": [100, 63.5, 94.8, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 6
                             "question": qsTr("How long does it take for Jupiter to make one revolution around the Sun?"),
                             "options": [qsTr("5 Earth years"), qsTr("12 Earth years"), qsTr("30 Earth years"), qsTr("1 Earth year")],
-                            "closeness": [61.5, 100, 1, 39.5]
+                            "closeness": [61.5, 100, 1, 39.5],
+                            "hintprovide": 1
                         }
                     ]
                 },
@@ -272,32 +310,38 @@ function get() {
                         { 	// sub-level 1
                             "question": qsTr("At which position is Saturn in the Solar System?"),
                             "options": [qsTr("Sixth"), qsTr("Fourth"), qsTr("First"), qsTr("Fifth")],
-                            "closeness": [100, 60.4, 1, 80]
+                            "closeness": [100, 60.4, 1, 80],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 2
                             "question": qsTr("How large is Saturn compared to other planets in the Solar System?"),
                             "options": [qsTr("Third largest"), qsTr("Largest"), qsTr("Fifth largest"), qsTr("Second largest")],
-                            "closeness": [67, 67, 1, 100]
+                            "closeness": [67, 67, 1, 100],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 3
                             "question": qsTr("How many moons has Saturn?"),
                             "options": ["120", "1", "82", "200"],
-                            "closeness": [32.2, 1, 100, 1]
+                            "closeness": [32.2, 1, 100, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 4
                             "question": qsTr("How long is one rotation on Saturn?"),
                             "options": [qsTr("10.5 hours"), qsTr("24 hours"), qsTr("12 hours"), qsTr("48 hours")],
-                            "closeness": [100, 64.3, 96, 1]
+                            "closeness": [100, 64.3, 96, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 5
                             "question": qsTr("The minimum temperature on Saturn is:"),
                             "options": [qsTr("0 °C"), qsTr("100 °C"), qsTr("-178 °C"), qsTr("-100 °C")],
-                            "closeness": [36.6, 1, 100, 72]
+                            "closeness": [36.6, 1, 100, 72],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 6
                             "question": qsTr("How long does it take for Saturn to make one revolution around the Sun?"),
                             "options": [qsTr("29.5 Earth years"), qsTr("20 Earth years"), qsTr("10 Earth years"), qsTr("1 Earth year")],
-                            "closeness": [100, 67, 32, 1]
+                            "closeness": [100, 67, 32, 1],
+                            "hintprovide": 1
                         }
                     ]
                 },
@@ -311,32 +355,38 @@ function get() {
                         { 	// sub-level 1
                             "question": qsTr("At which position is Uranus in the Solar System?"),
                             "options": [qsTr("Seventh"), qsTr("Fourth"), qsTr("Eighth"), qsTr("Fifth")],
-                            "closeness": [100, 1, 67, 34]
+                            "closeness": [100, 1, 67, 34],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 2
                             "question": qsTr("How many years does it take for Uranus to go once around the Sun?"),
                             "options": [qsTr("1 year"), qsTr("24 years"), qsTr("68 years"), qsTr("84 years")],
-                            "closeness": [1, 28.4, 81, 100]
+                            "closeness": [1, 28.4, 81, 100],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 3
                             "question": qsTr("How many moons has Uranus?"),
                             "options": ["120", "87", "27", "50"],
-                            "closeness": [1, 36, 100, 75.5]
+                            "closeness": [1, 36, 100, 75.5],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 4
                             "question": qsTr("How long is one rotation on Uranus?"),
                             "options": [qsTr("10 hours"), qsTr("27 hours"), qsTr("17 hours"), qsTr("48 hours")],
-                            "closeness": [77.6, 68, 100, 1]
+                            "closeness": [77.6, 68, 100, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 5
                             "question": qsTr("How large is Uranus compared to other planets in the Solar System?"),
                             "options": [qsTr("Third largest"), qsTr("Largest"), qsTr("Seventh largest"), qsTr("Second largest")],
-                            "closeness": [100, 50.5, 1, 75]
+                            "closeness": [100, 50.5, 1, 75],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 6
                             "question": qsTr("The maximum temperature on Uranus is:"),
                             "options": [qsTr("100 °C"), qsTr("-216 °C"), qsTr("0 °C"), qsTr("-100 °C")],
-                            "closeness": [1, 100, 32.3, 63.6]
+                            "closeness": [1, 100, 32.3, 63.6],
+                            "hintprovide": 1
                         }
                     ]
                 },
@@ -350,32 +400,38 @@ function get() {
                         { 	// sub-level 1
                             "question": qsTr("At which position is Neptune in the Solar System?"),
                             "options": [qsTr("Seventh"), qsTr("Fourth"), qsTr("Eighth"), qsTr("Fifth")],
-                            "closeness": [75, 1, 100, 25.7]
+                            "closeness": [75, 1, 100, 25.7],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 2
                             "question": qsTr("How long does it take for Neptune to make one revolution around the Sun?"),
                             "options": [qsTr("165 years"), qsTr("3 years"), qsTr("100 years"), qsTr("1 year")],
-                            "closeness": [100, 2, 60.7, 1]
+                            "closeness": [100, 2, 60.7, 1],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 3
                             "question": qsTr("How many moons has Neptune?"),
                             "options": ["120", "87", "14", "50"],
-                            "closeness": [1, 31.8, 100, 66.3]
+                            "closeness": [1, 31.8, 100, 66.3],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 4
                             "question": qsTr("How long is one rotation on Neptune?"),
                             "options": [qsTr("16 hours"), qsTr("27 hours"), qsTr("17 hours"), qsTr("48 hours")],
-                            "closeness": [100, 66, 97, 1]
+                            "closeness": [100, 66, 97, 1],
+                            "hintprovide": 0
                         },
                         { 	// sub-level 5
                             "question": qsTr("The average temperature on Neptune is:"),
                             "options": [qsTr("100 °C"), qsTr("30 °C"), qsTr("-210 °C"), qsTr("-100 °C")],
-                            "closeness": [1, 23, 100, 64]
+                            "closeness": [1, 23, 100, 64],
+                            "hintprovide": 1
                         },
                         { 	// sub-level 6
                             "question": qsTr("How large is Neptune compared to other planets in the Solar System?"),
                             "options": [qsTr("Fourth largest"), qsTr("Largest"), qsTr("Third largest"), qsTr("Second largest")],
-                            "closeness": [100, 1, 67, 34]
+                            "closeness": [100, 1, 67, 34],
+                            "hintprovide": 0
                         }
                     ]
                 }

--- a/src/activities/solar_system/SolarSystem.qml
+++ b/src/activities/solar_system/SolarSystem.qml
@@ -35,7 +35,7 @@ ActivityBase {
         id: background
         anchors.fill: parent
         property bool horizontalLayout: background.width >= background.height
-        
+
         Image {
             id: stars
             fillMode: Image.PreserveAspectCrop
@@ -55,7 +55,7 @@ ActivityBase {
                 }
             }
         }
-        
+
         signal start
         signal stop
 
@@ -79,6 +79,7 @@ ActivityBase {
             property bool quizScreenVisible: false
             property string temperatureHint
             property string lengthOfYearHint
+            property string positionOfPlanetHint
         }
 
         onStart: {
@@ -248,7 +249,7 @@ ActivityBase {
                     planetSize: bodySize
                 }
             }
-            
+
             NumberAnimation {
                 id: hintAppearAnimation
                 target: solarSystemImageHint
@@ -286,14 +287,29 @@ ActivityBase {
 
             readonly property string hint1: qsTr("1. The <b>farther</b> a planet from the Sun, the <b>lower</b> is its temperature.<br><font color=\"#3bb0de\">%1</font>").arg(items.temperatureHint)
             readonly property string hint2: qsTr("2. The duration of a year on a planet <b>increases as we go away from the Sun</b>.<br><font color=\"#3bb0de\">%1</font>").arg(items.lengthOfYearHint)
+            readonly property string hint3: qsTr("3. Always remember this Rhyme to learn the position of planets , examine the first letter in each word - <b>M</b>y <b>V</b>ery <b>E</b>xcellent <b>M</b>other <b>J</b>ust <b>S</b>erved <b>U</b>s <b>N</b>oodles.<br><font color=\"#3bb0de\">%1</font>").arg(items.positionOfPlanetHint)
 
             title: qsTr("Hint")
-            content: "%1<br>%2".arg(hint1).arg(hint2)
+            content: "%1<br>%2<br>%3".arg(hint1).arg(hint2).arg(hint3)
             onClose: {
                 solarSystemImageHint.visible = false
                 home()
             }
 
+            button0Text: qsTr("View solar system")
+
+            onButton0Hit: solarSystemImageHint.visible = true
+        }
+
+        DialogBackground {
+            id: nohint
+            visible: false
+            title: qsTr("Hint")
+            content: "Sorry No Hint Available For This Question !!"
+            onClose: {
+                solarSystemImageHint.visible = false
+                home()
+            }
             button0Text: qsTr("View solar system")
 
             onButton0Hit: solarSystemImageHint.visible = true
@@ -384,8 +400,14 @@ ActivityBase {
             onHintClicked: {
                 if(items.assessmentMode)
                     solarSystemImageHint.visible = true
-                else
-                    displayDialog(hintDialog)
+                else{
+                    if(Activity.hintprovide===1 ){
+                        displayDialog(hintDialog)
+                }
+                    else{
+                        displayDialog(nohint)
+                    }
+                }
             }
             onConfigClicked: {
                 dialogActivityConfig.active = true

--- a/src/activities/solar_system/solar_system.js
+++ b/src/activities/solar_system/solar_system.js
@@ -32,6 +32,7 @@ var currentSubLevel
 var indexOfSelectedPlanet
 var assessmentModeQuestions = []
 var allQuestions = []
+var hintprovide
 
 function start(items_) {
     items = items_
@@ -74,6 +75,7 @@ function nextSubLevel(isAssessmentMode) {
         }
         else {
             items.mainQuizScreen.question = currentPlanetLevels[currentSubLevel].question
+            hintprovide = currentPlanetLevels[currentSubLevel].hintprovide
             for(var i = 0 ; i < 4 ; i ++) {
                 optionListShuffle.push({
                     "optionValue": currentPlanetLevels[currentSubLevel].options[i],


### PR DESCRIPTION
I have worked on the task T12339 under the junior jobs .

- Currently only 2 questions (temperature and revolution) have hints.
- I have added an additional hint for the question of positions of planets . I thought providing a rhyme will help students to learn postions easily.
- For other questions as the answers are too random so no hints are given , when hint button is clicked  a DialogBackground is shown to tell there is no hint .

Please review this and tell me if any changes are required .