### PR TITLE
Share, updated the candy limit of a receiver

### DIFF
--- a/src/activities/share/Share.qml
+++ b/src/activities/share/Share.qml
@@ -55,7 +55,7 @@ ActivityBase {
             property int barHeightAddon: ApplicationSettings.isBarHidden ? 1 : 3
             property int cellSize: Math.round(Math.min(background.width / 12, background.height / (11 + barHeightAddon)))
             property alias repeaterDropAreas: repeaterDropAreas
-            property int maxNumberOfCandiesPerWidget: 8
+            property int maxNumberOfCandiesPerWidget: 6
         }
 
         onStart: { Activity.start(items) }


### PR DESCRIPTION
Before the fix, the candy limit of a receiver was 8, which caused the candies to come out of the drop area of a receiver. Now I have changed the limit to 6, which fixes the issue.