### PR TITLE
Updated with needs of Debian 11 and Raspberry Pi

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -52,17 +52,23 @@ be installed
 
 Installing dependencies on a Debian based systems can be done like this:
 
-    sudo aptitude install libqt5svg5-dev \
-                          qml-module-qtmultimedia qt5-default \
+    sudo apt install libqt5svg5-dev \
+                          qml-module-qtmultimedia \
                           qml-module-qtgraphicaleffects qt5-qmake qtcreator \
                           qtdeclarative5-dev qtdeclarative5-dev \
-                          qtmultimedia5-dev qtquick1-5-dev qttools5-dev \
+                          qtmultimedia5-dev qtquickcontrols2-5-dev qttools5-dev \
                           qttools5-dev-tools libqt5multimedia5-plugins \
                           qml-module-qtsensors libqt5quickparticles5 \
                           qml-module-qtquick2 qml-module-qtquick-particles2 \
                           libqt5sensors5-dev libqt5sensors5
 
 To build for Android, Qt 5 AndroidExtras also needs to be installed.
+
+If building from a .tar.gz or .zip source distribution the externals may
+need to be added.
+
+    cd GCompris-qt-*
+    git clone https://github.com/qml-box2d/qml-box2d.git external/qml-box2d/
 
 
 Build
@@ -71,6 +77,15 @@ Start QtCreator and select Open Project and open CMakeLists.txt in the
 gcompris-qt root directory. Follow the wizard instructions.
 
 Use the buttons on the lower left side to build, run, and debug GCompris.
+
+An alternative building process is to use cmake.
+
+    sudo apt install cmake # If not already installed
+    cd GCompris-qt-*
+    mkdir build
+    cd build
+    cmake ..
+    make
 
 More Details
 ------------

--- a/HACKING
+++ b/HACKING
@@ -86,6 +86,7 @@ An alternative building process is to use cmake.
     cd build
     cmake ..
     make
+    ./bin/gcompris-qt
 
 More Details
 ------------


### PR DESCRIPTION
Instructions for building on fresh Debian 11.2 and Raspberry Pi's. I was not able to figure out QtCreator so added example of cmake alternative.